### PR TITLE
Refactor from addNestedCallback to use withParents instead

### DIFF
--- a/src/ServiceDelivery/Base.php
+++ b/src/ServiceDelivery/Base.php
@@ -116,7 +116,7 @@ abstract class Base
 
         $this->reader->open($this->xmlFile->getPath());
         $this->reader
-            ->addCallback(['Siri', 'ServiceDelivery', 'ProducerRef'], function ($reader) {
+            ->addCallback(['Siri', 'ServiceDelivery', 'ProducerRef'], function (ChristmasTreeParser $reader) {
                 $this->producerRef = trim($reader->readString());
             })
             ->addCallback(['Siri', 'ServiceDelivery', $chanElement], function () {
@@ -124,7 +124,12 @@ abstract class Base
                 $this->elementCount = 0;
                 $this->payload = [];
             })
-            ->withParents(['Siri', 'ServiceDelivery', $chanElement], [$this, 'setupHandlers'])
+            ->withParents(['Siri', 'ServiceDelivery', $chanElement], function (ChristmasTreeParser $reader) {
+                $reader->addCallback(['ResponseTimestamp'], [$this, 'readResponseTimestamp'])
+                    ->addCallback(['SubscriberRef'], [$this, 'readSubscriberRef'])
+                    ->addCallback(['SubscriptionRef'], [$this, 'verifySubscriptionRef']);
+                $this->setupHandlers();
+            })
             ->parse()
             ->close();
         $this->emitPayload();

--- a/src/ServiceDelivery/EstimatedTimetableDelivery.php
+++ b/src/ServiceDelivery/EstimatedTimetableDelivery.php
@@ -117,7 +117,7 @@ class EstimatedTimetableDelivery extends Base
      */
     public function setupHandlers()
     {
-        $this->reader->addNestedCallback(
+        $this->reader->addCallback(
             ['EstimatedJourneyVersionFrame', 'EstimatedVehicleJourney'],
             [$this, 'estimatedVehicleJourney']
         );

--- a/src/ServiceDelivery/SituationExchangeDelivery.php
+++ b/src/ServiceDelivery/SituationExchangeDelivery.php
@@ -163,8 +163,8 @@ class SituationExchangeDelivery extends Base
     public function setupHandlers()
     {
         $this->reader
-            ->addNestedCallback(['Situations', 'PtSituationElement'], [$this, 'parsePtSituation'])
-            ->addNestedCallback(['Situations', 'RoadSituationElement'], [$this, 'parseRoadSituation']);
+            ->addCallback(['Situations', 'PtSituationElement'], [$this, 'parsePtSituation'])
+            ->addCallback(['Situations', 'RoadSituationElement'], [$this, 'parseRoadSituation']);
     }
 
     /**

--- a/src/ServiceDelivery/VehicleMonitoringDelivery.php
+++ b/src/ServiceDelivery/VehicleMonitoringDelivery.php
@@ -121,7 +121,7 @@ class VehicleMonitoringDelivery extends Base
      */
     public function setupHandlers()
     {
-        $this->reader->addNestedCallback(['VehicleActivity'], [$this, 'vehicleActivity']);
+        $this->reader->addCallback(['VehicleActivity'], [$this, 'vehicleActivity']);
     }
 
     /**


### PR DESCRIPTION
This uses the latest rev of ChristmasTreeParser with the additional `::withParents()` callback to inject callback handlers down the XML tree before the parsing begins.

The problem with using `addNestedCallback()` is that you are adding callback handlers after the parsing has begun, which may cause piling up of callback handlers for repetitive elements.