### PR TITLE
Fix subscription checks and url link handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,18 @@
 composer.lock
-/vendor/
 /node_modules
-/package-lock.json
+/public
+/vendor
 
 # Code indexing and editor tools
-/.ac-php-conf.json
-/.tern-port
+.ac-php-conf.json
+.tern-port
 .php_cs.cache
-/.eslintcache
-/_ide_helper*
+.phpactor.json
+.eslintcache
+_ide_helper*
 
 # Auto-generated files
 .log/
+package-lock.json
+mix-manifest.json
 npm-debug.log

--- a/database/migrations/2024_10_02_125556_siri_rename_info_link_uri.php
+++ b/database/migrations/2024_10_02_125556_siri_rename_info_link_uri.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('siri_sx_info_link', function (Blueprint $table) {
+            $table->renameColumn('url', 'uri');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('siri_sx_info_link', function (Blueprint $table) {
+            $table->renameColumn('uri', 'url');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,7 +7,7 @@ use TromsFylkestrafikk\Siri\Http\Controllers\PtSituationController;
 Route::post('consume/{channel}/{subscription:subscription_ref}', [SiriClientController::class, 'consume'])
     ->name('siri.consume')
     ->where('channel', '(VM|ET|SX)')
-    ->middleware('siri.channel');
+    ->middleware(['siri.active', 'siri.channel']);
 
 Route::apiResource('pt-situation', PtSituationController::class)->only(['index', 'show']);
 

--- a/src/Helpers/PtSituationToModel.php
+++ b/src/Helpers/PtSituationToModel.php
@@ -170,10 +170,9 @@ class PtSituationToModel
             return;
         }
         foreach ($networks as $network) {
-            if (empty($network['affected_line'])) {
-                continue;
+            if (!empty($network['affected_line'])) {
+                $this->storeAffectedLines($network['affected_line']);
             }
-            $this->storeAffectedLines($network['affected_line']);
         }
     }
 

--- a/src/Http/Middleware/ActiveChannel.php
+++ b/src/Http/Middleware/ActiveChannel.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace TromsFylkestrafikk\Siri\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use TromsFylkestrafikk\Siri\Models\SiriSubscription;
+
+class ActiveChannel
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
+     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        /** @var SiriSubscription $subscription */
+        $subscription = $request->route('subscription');
+        if (!$subscription->active) {
+            return response('Subscription is set on hold', Response::HTTP_FORBIDDEN);
+        }
+        return $next($request);
+    }
+}

--- a/src/Models/Sx/InfoLink.php
+++ b/src/Models/Sx/InfoLink.php
@@ -25,8 +25,8 @@ class InfoLink extends Model
     use HasFactory;
 
     public $timestamps = false;
-    protected $table = 'siri_sx_affected_line';
-    protected $fillable = ['pt_situation_id', 'url', 'label'];
+    protected $table = 'siri_sx_info_link';
+    protected $fillable = ['pt_situation_id', 'uri', 'label'];
 
     public function ptSituation()
     {

--- a/src/SiriServiceProvider.php
+++ b/src/SiriServiceProvider.php
@@ -12,6 +12,7 @@ use TromsFylkestrafikk\Siri\Console\ReSubscribe;
 use TromsFylkestrafikk\Siri\Console\TerminateSubscription;
 use TromsFylkestrafikk\Siri\Jobs\PeriodicResubscribe;
 use TromsFylkestrafikk\Siri\Http\Middleware\SiriVersion;
+use TromsFylkestrafikk\Siri\Http\Middleware\ActiveChannel;
 use TromsFylkestrafikk\Siri\Http\Middleware\SubscribedChannel;
 use TromsFylkestrafikk\Siri\Services\CaseStyler;
 
@@ -70,6 +71,7 @@ class SiriServiceProvider extends ServiceProvider
     {
         /** @var \Illuminate\Routing\Router $router */
         $router = $this->app->make(Router::class);
+        $router->aliasMiddleware('siri.active', ActiveChannel::class);
         $router->aliasMiddleware('siri.channel', SubscribedChannel::class);
         $router->aliasMiddleware('siri.version', SiriVersion::class);
     }

--- a/src/Subscription/RequestBase.php
+++ b/src/Subscription/RequestBase.php
@@ -119,11 +119,8 @@ class RequestBase
         $message = null;
         if (!$xml) {
             $message = "Invalid XML.";
-        } else {
-            $status = ((string) $xml->SubscriptionResponse->ResponseStatus->Status) ?: 'true';
-            if ($status !== 'true') {
-                $message = "Response XML dumped to disk.";
-            }
+        } elseif (((string) $xml->SubscriptionResponse->ResponseStatus->Status) !== 'true') {
+            $message = "Invalid SubscriptionResponse status.";
         }
         if ($message) {
             Log::error(sprintf(

--- a/src/Subscription/RequestBase.php
+++ b/src/Subscription/RequestBase.php
@@ -117,16 +117,9 @@ class RequestBase
         // @var \SimpleXMLElement $xml
         $xml = simplexml_load_string($xmlStr, SimpleXMLElement::class, 0, self::NAMESPACE_SIRI);
         $status = ((string) $xml->SubscriptionResponse->ResponseStatus->Status) ?: 'true';
-        $requestMessageRef = (string) $xml->SubscriptionResponse->RequestMessageRef;
-        Log::debug(sprintf(
-            "Comparing reponse RequestMessageRef (%s) with our own messageId (%s)",
-            $requestMessageRef,
-            $this->messageId
-        ));
         if (
             !$xml
             || !$xml->SubscriptionResponse
-            || $requestMessageRef !== $this->messageId
             || $status !== 'true'
         ) {
             Log::error(sprintf(

--- a/src/Subscription/RequestBase.php
+++ b/src/Subscription/RequestBase.php
@@ -116,16 +116,21 @@ class RequestBase
     {
         // @var \SimpleXMLElement $xml
         $xml = simplexml_load_string($xmlStr, SimpleXMLElement::class, 0, self::NAMESPACE_SIRI);
-        $status = ((string) $xml->SubscriptionResponse->ResponseStatus->Status) ?: 'true';
-        if (
-            !$xml
-            || !$xml->SubscriptionResponse
-            || $status !== 'true'
-        ) {
+        $message = null;
+        if (!$xml) {
+            $message = "Invalid XML.";
+        } else {
+            $status = ((string) $xml->SubscriptionResponse->ResponseStatus->Status) ?: 'true';
+            if ($status !== 'true') {
+                $message = "Response XML dumped to disk.";
+            }
+        }
+        if ($message) {
             Log::error(sprintf(
-                "SIRI %s subscription to service '%s' failed. Dumping response XML.",
+                "SIRI %s subscription to service '%s' failed: %s",
                 $this->subscription->channel,
-                $this->subscription->subscription_url
+                $this->subscription->subscription_url,
+                $message
             ));
             $this->dumpResponseXml($xmlStr);
             return false;

--- a/src/Subscription/RequestBase.php
+++ b/src/Subscription/RequestBase.php
@@ -117,10 +117,16 @@ class RequestBase
         // @var \SimpleXMLElement $xml
         $xml = simplexml_load_string($xmlStr, SimpleXMLElement::class, 0, self::NAMESPACE_SIRI);
         $status = ((string) $xml->SubscriptionResponse->ResponseStatus->Status) ?: 'true';
+        $requestMessageRef = (string) $xml->SubscriptionResponse->RequestMessageRef;
+        Log::debug(sprintf(
+            "Comparing reponse RequestMessageRef (%s) with our own messageId (%s)",
+            $requestMessageRef,
+            $this->messageId
+        ));
         if (
             !$xml
             || !$xml->SubscriptionResponse
-            || (string) $xml->SubscriptionResponse->RequestMessageRef !== $this->messageId
+            || $requestMessageRef !== $this->messageId
             || $status !== 'true'
         ) {
             Log::error(sprintf(


### PR DESCRIPTION
URLs provided by SIRI SX wasn't parsed properly. And the subscription response mechanism was flawed with an unecessary id check.

- InfoLink `url` were renamed to `uri` as specified in the siri standard.
- Subscription response check were hardened.