### PR TITLE
fix: Include situations with empty `validity_end` column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
+## [Unreleased]
+### Fixed
+- Include situations with no validity_end column.
+
 ## [0.3.2] – 2024-10-03
-## Added
+### Added
 - Client now compatible with Enturs SIRI service.
 
-## Fixed
+### Fixed
 - Info links are properly parsed and added to DB
 
 ## [0.3.1] – 2024-09-18
@@ -12,7 +16,7 @@
 - Option to close all situations prior to SX subscription. Useful when
   SX state differ between publisher and subscriber.
 
-## Changed
+### Changed
 - Query scope for `PtSituation`s now include future situations too.
 - Updated ChristmasTreeParser and adjusted callback handling for it.
 

--- a/src/Models/Scopes/SituationValid.php
+++ b/src/Models/Scopes/SituationValid.php
@@ -16,7 +16,11 @@ class SituationValid implements Scope
      */
     public function apply(Builder $builder, Model $model)
     {
-        $now = now();
-        $builder->where('validity_end', '>', $now);
+        $builder->where(function (Builder $query) {
+            $now = now();
+            $query->whereNull('validity_end')
+                ->orWhereNot('validity_end')
+                ->orWhere('validity_end', '>', $now);
+        });
     }
 }


### PR DESCRIPTION
This fixes a query scope included in the PtSituation model where date had to be between start and end. It now allows empty end.