### PR TITLE
fix: Fix faulty filter for future situations validity period

### DIFF
--- a/src/Models/Scopes/SituationValid.php
+++ b/src/Models/Scopes/SituationValid.php
@@ -17,10 +17,8 @@ class SituationValid implements Scope
     public function apply(Builder $builder, Model $model)
     {
         $builder->where(function (Builder $query) {
-            $now = now();
             $query->whereNull('validity_end')
-                ->orWhereNot('validity_end')
-                ->orWhere('validity_end', '>', $now);
+                ->orWhere('validity_end', '>', now());
         });
     }
 }


### PR DESCRIPTION
The situations downloaded to RTM is overloaded with irrelevant situations. Situations with no `validity_end` column is in DB set to `NULL`. This fixes the issue with flooding the initial pt_situation request with s*loads of useless situations.

This is just the `laravel-siri` part. It still have to be included in RTM.