### PR TITLE
fix: Default value of SubscriptionRef is OK.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- SubscriptionRef in incoming dumps are optional.
+
 ## [0.3.6] → 2025-04-22
 
 ### Fixed

--- a/src/ServiceDelivery/Base.php
+++ b/src/ServiceDelivery/Base.php
@@ -99,7 +99,7 @@ abstract class Base
     {
         $this->subscription = $subscription;
         $this->xmlFile = $xmlFile;
-        $this->subscriptionVerified = false;
+        $this->subscriptionVerified = true;
         $this->setLogPrefix('Siri-%s[%d]: ', $subscription->channel, $subscription->id);
         $this->haltOnSubscription = env('APP_ENV' !== 'local') || request()->root() !== env('APP_URL');
         $this->maxChunkSize = config('siri.event_chunk_size.' . $subscription->channel);


### PR DESCRIPTION
The callback for matched XML element `Siri>ServiceDelivery>[SIRITYPE]>SubscriptionRef` will only set the status if it exists, so the default value set in the constructor is set to `true`.